### PR TITLE
Update gemini 3h

### DIFF
--- a/aws/gemini-3h/main.tf
+++ b/aws/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-19"
+    docker-tag         = "gemini-3h-2024-mar-04"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-19"
+    docker-tag         = "gemini-3h-2024-mar-04"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-19"
+    docker-tag         = "gemini-3h-2024-mar-04"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-19"
+    docker-tag         = "gemini-3h-2024-mar-04"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-19"
+    docker-tag         = "gemini-3h-2024-mar-04"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3h-2024-feb-19"
+    docker-tag             = "gemini-3h-2024-mar-04"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"

--- a/aws/gemini-3h/main.tf
+++ b/aws/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-15"
+    docker-tag         = "gemini-3h-2024-feb-19"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-15"
+    docker-tag         = "gemini-3h-2024-feb-19"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-15"
+    docker-tag         = "gemini-3h-2024-feb-19"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-15"
+    docker-tag         = "gemini-3h-2024-feb-19"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-15"
+    docker-tag         = "gemini-3h-2024-feb-19"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3h-2024-feb-15"
+    docker-tag             = "gemini-3h-2024-feb-19"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"

--- a/aws/gemini-3h/main.tf
+++ b/aws/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-05"
+    docker-tag         = "gemini-3h-2024-feb-15"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-05"
+    docker-tag         = "gemini-3h-2024-feb-15"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-05"
+    docker-tag         = "gemini-3h-2024-feb-15"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-05"
+    docker-tag         = "gemini-3h-2024-feb-15"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-feb-05"
+    docker-tag         = "gemini-3h-2024-feb-15"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3h-2024-feb-05"
+    docker-tag             = "gemini-3h-2024-feb-15"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"


### PR DESCRIPTION
The PR bumps release versions for gemini-3h:
- https://github.com/subspace/subspace/releases/tag/gemini-3h-2024-feb-15
- https://github.com/subspace/subspace/releases/tag/gemini-3h-2024-feb-19
- https://github.com/subspace/subspace/releases/tag/gemini-3h-2024-mar-04