### PR TITLE
dns: add subspace.tools (GitHub Pages) records

### DIFF
--- a/resources/terraform/dns/data.tf
+++ b/resources/terraform/dns/data.tf
@@ -52,6 +52,12 @@ data "cloudflare_zone" "subspace_network" {
   }
 }
 
+data "cloudflare_zone" "subspace_tools" {
+  filter = {
+    name = "subspace.tools"
+  }
+}
+
 locals {
   proxied_data = jsondecode(file("${path.module}/proxied.json"))
 }

--- a/resources/terraform/dns/subspace_tools.tf
+++ b/resources/terraform/dns/subspace_tools.tf
@@ -1,0 +1,59 @@
+resource "cloudflare_dns_record" "subspace_tools_apex_1" {
+  content  = "185.199.108.153"
+  name     = "subspace.tools"
+  proxied  = false
+  ttl      = 1
+  type     = "A"
+  zone_id  = data.cloudflare_zone.subspace_tools.zone_id
+  settings = {}
+}
+
+resource "cloudflare_dns_record" "subspace_tools_apex_2" {
+  content  = "185.199.109.153"
+  name     = "subspace.tools"
+  proxied  = false
+  ttl      = 1
+  type     = "A"
+  zone_id  = data.cloudflare_zone.subspace_tools.zone_id
+  settings = {}
+}
+
+resource "cloudflare_dns_record" "subspace_tools_apex_3" {
+  content  = "185.199.110.153"
+  name     = "subspace.tools"
+  proxied  = false
+  ttl      = 1
+  type     = "A"
+  zone_id  = data.cloudflare_zone.subspace_tools.zone_id
+  settings = {}
+}
+
+resource "cloudflare_dns_record" "subspace_tools_apex_4" {
+  content  = "185.199.111.153"
+  name     = "subspace.tools"
+  proxied  = false
+  ttl      = 1
+  type     = "A"
+  zone_id  = data.cloudflare_zone.subspace_tools.zone_id
+  settings = {}
+}
+
+resource "cloudflare_dns_record" "subspace_tools_www" {
+  content  = "autonomys-community.github.io"
+  name     = "www.subspace.tools"
+  proxied  = false
+  ttl      = 1
+  type     = "CNAME"
+  zone_id  = data.cloudflare_zone.subspace_tools.zone_id
+  settings = {}
+}
+
+resource "cloudflare_dns_record" "subspace_tools_github_pages_challenge" {
+  content  = "7925f03f5b678341e6a6338360bc89"
+  name     = "_github-pages-challenge-autonomys-community.subspace.tools"
+  proxied  = false
+  ttl      = 1
+  type     = "TXT"
+  zone_id  = data.cloudflare_zone.subspace_tools.zone_id
+  settings = {}
+}


### PR DESCRIPTION
## What

Adds `subspace.tools` DNS to the `dns` Cloudflare workspace:
- `data.tf` — `subspace.tools` zone data source
- `subspace_tools.tf` — 6 records mirroring the zone currently served from GoDaddy DNS

`subspace.tools` is the rebranded home of the Subspace Tools site (repo: `autonomys-community/subspace-tools`), served by GitHub Pages. This brings its DNS under Terraform/Cloudflare so we can retire the interim GoDaddy-hosted zone.

## Records (all DNS-only)

| Type | Name | Value |
|------|------|-------|
| A | subspace.tools | 185.199.108.153 |
| A | subspace.tools | 185.199.109.153 |
| A | subspace.tools | 185.199.110.153 |
| A | subspace.tools | 185.199.111.153 |
| CNAME | www.subspace.tools | autonomys-community.github.io |
| TXT | _github-pages-challenge-autonomys-community.subspace.tools | 7925f03f5b678341e6a6338360bc89 |

These are an exact mirror of the live GoDaddy zone (verified via `dig` against the current authoritative nameservers), so the nameserver cutover is like-for-like — resolvers get identical answers before and after.

**All records are `proxied = false` (DNS-only) on purpose.** GitHub Pages terminates TLS itself; proxying the apex/`www` through Cloudflare breaks Let's Encrypt cert issuance/renewal and can cause redirect loops. The `_github-pages-challenge` TXT backs GitHub's org-level domain verification for `autonomys-community` and must keep resolving, or the verified-domain status lapses.

## Prerequisites / notes for the infra team

1. **The `subspace.tools` zone must exist in Cloudflare before apply.** The zone is referenced as a data source, so `terraform plan` will fail until the domain is added to the Cloudflare account. Adding it also generates the Cloudflare nameservers used in the cutover below.
2. **Watch for auto-imported records.** When the zone is added, Cloudflare auto-scans GoDaddy and may import records. Please ensure the applied zone ends up with exactly the six records above (remove any strays) so `plan` is clean and Terraform fully owns the set.
3. No `proxied.json` changes are needed — every record here is DNS-only.

## Cutover (no downtime; done after apply, at our own pace)

1. Apply this PR (records now exist in Cloudflare, but GoDaddy is still authoritative — no traffic moved yet).
2. Verify the records resolve via the zone's assigned Cloudflare nameservers (`dig @<cf-ns> subspace.tools`, `www`, and the TXT) and match the table above.
3. At GoDaddy, switch the nameservers from `pdns09/pdns10.domaincontrol.com` to the two Cloudflare nameservers. **This is the only cutover moment**, and it's seamless because Cloudflare already serves identical answers.
4. After propagation, verify: apex/`www`/TXT resolve, `https://subspace.tools` loads with a valid cert, and GitHub Pages still shows the domain verified with HTTPS enforced.

**Rollback:** revert the nameservers at GoDaddy — its zone stays fully intact, returning the site to its current working state.
