### PR TITLE
Right-size chronos AWS nodes (cost reduction)

### DIFF
--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -31,7 +31,7 @@ module "chronos" {
   }
 
   consensus-rpc-node-config = {
-    instance-type        = "c7a.4xlarge"
+    instance-type        = "c7a.xlarge"
     dns-prefix           = "rpc"
     disk-volume-size     = var.disk_volume_size
     disk-volume-type     = var.disk_volume_type

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -102,7 +102,7 @@ module "chronos" {
   }
 
   domain-operator-node-config = {
-    instance-type    = "c7a.2xlarge"
+    instance-type    = "c7a.large"
     disk-volume-size = var.disk_volume_size
     disk-volume-type = var.disk_volume_type
     operator-nodes = [

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -67,7 +67,7 @@ module "chronos" {
   }
 
   domain-bootstrap-node-config = {
-    instance-type    = "c7a.2xlarge"
+    instance-type    = "c7a.large"
     disk-volume-size = var.disk_volume_size
     disk-volume-type = var.disk_volume_type
     bootstrap-nodes = [

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -83,7 +83,7 @@ module "chronos" {
   }
 
   domain-rpc-node-config = {
-    instance-type        = "c7a.4xlarge"
+    instance-type        = "c7a.2xlarge"
     disk-volume-size     = var.disk_volume_size
     disk-volume-type     = var.disk_volume_type
     enable-reverse-proxy = true


### PR DESCRIPTION
Right-sizes the chronos AWS node instances to fit actual usage. Over a 14-day window these run at 7-27% CPU on 8-16 vCPU boxes using ~2-3 GiB RAM, so they are heavily over-provisioned.

- consensus-rpc: c7a.4xlarge to c7a.xlarge
- domain-rpc: c7a.4xlarge to c7a.2xlarge (keeps headroom for the auto-evm RPC peak)
- domain-bootstrap: c7a.2xlarge to c7a.large
- domain operators (both): c7a.2xlarge to c7a.large

All are in-place instance_type changes (stop, resize, start on the same EBS volume), so no data is lost and nodes resume from existing state without resyncing. Applied one node at a time and verified each catches back up to tip. About ~$1.4k/mo on the chronos nodes. Reversible by bumping the type back up.