### PR TITLE
Right-size chronos service boxes (cost reduction)

### DIFF
--- a/resources/terraform/chronos-chain-alerter/main.tf
+++ b/resources/terraform/chronos-chain-alerter/main.tf
@@ -21,7 +21,7 @@ module "chronos_chain_alerter" {
   instance = {
     network_name               = "chronos"
     docker_tag                 = "v1.2.1"
-    instance_type              = "c3.xlarge"
+    instance_type              = "t3.medium"
     rpc_url                    = "wss://rpc.chronos.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url
     slack_secret               = var.slack_secret

--- a/resources/terraform/chronos-chain-indexer/main.tf
+++ b/resources/terraform/chronos-chain-indexer/main.tf
@@ -22,7 +22,7 @@ module "chronos_chain_indexer" {
     network_name               = "chronos"
     domain_fqdn                = "autonomys.xyz"
     docker_tag                 = "v1.2.1"
-    instance_type              = "c3.xlarge"
+    instance_type              = "c7a.large"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"
     consensus_rpc              = "wss://rpc.chronos.autonomys.xyz/ws"

--- a/resources/terraform/chronos-reward-distributor/main.tf
+++ b/resources/terraform/chronos-reward-distributor/main.tf
@@ -22,7 +22,7 @@ module "chronos_reward_distributor" {
   instance = {
     network_name        = "chronos"
     docker_tag          = "latest"
-    instance_type       = "c3.large"
+    instance_type       = "t3.medium"
     rpc_url             = "wss://auto-evm.chronos.autonomys.xyz/ws"
     interval_seconds    = 60
     tip_ai3             = 0.01


### PR DESCRIPTION
Right-sizes the three chronos service instances off the old c3 generation to fit actual usage (all three run under 700 MB and near-idle CPU over 14 days).

- chain-alerter: c3.xlarge to t3.medium
- chain-indexer: c3.xlarge to c7a.large (non-burstable, keeps headroom for the indexer + Postgres)
- reward-distributor: c3.large to t3.medium

All in-place instance_type changes; service data is on the EBS root volume so it carries through the stop/resize/start (the c3 instance-store holds only scratch). Applied one at a time and verified. About ~$250/mo. Reversible.