### PR TITLE
Right-size mainnet boxes and re-provision nodes when their IP changes

### DIFF
--- a/modules/network-primitives/bootstrap_domain_node_provisioner.tf
+++ b/modules/network-primitives/bootstrap_domain_node_provisioner.tf
@@ -44,8 +44,10 @@ resource "null_resource" "start-domain-bootstrap-nodes" {
   count      = length(aws_instance.domain_bootstrap_nodes)
   depends_on = [null_resource.setup-domain-bootstrap-nodes]
 
-  # trigger node deployment of the node object changes
-  triggers = var.domain-bootstrap-node-config.bootstrap-nodes[count.index]
+  # trigger node re-deployment if the node config or its external IP changes
+  triggers = merge(var.domain-bootstrap-node-config.bootstrap-nodes[count.index], {
+    external-ip = aws_instance.domain_bootstrap_nodes[count.index].public_ip
+  })
 
   connection {
     host           = aws_instance.domain_bootstrap_nodes[count.index].public_ip

--- a/modules/network-primitives/bootstrap_node_provisioner.tf
+++ b/modules/network-primitives/bootstrap_node_provisioner.tf
@@ -44,8 +44,10 @@ resource "null_resource" "start-consensus-boostrap-nodes" {
   count      = length(aws_instance.consensus_bootstrap_nodes)
   depends_on = [null_resource.setup-consensus-bootstrap-nodes]
 
-  # trigger node re-deployment if anything changes in the node config
-  triggers = var.consensus-bootstrap-node-config.bootstrap-nodes[count.index]
+  # trigger node re-deployment if the node config or its external IP changes
+  triggers = merge(var.consensus-bootstrap-node-config.bootstrap-nodes[count.index], {
+    external-ip = aws_instance.consensus_bootstrap_nodes[count.index].public_ip
+  })
 
   connection {
     host           = aws_instance.consensus_bootstrap_nodes[count.index].public_ip

--- a/modules/network-primitives/domain_operator_node_provisioner.tf
+++ b/modules/network-primitives/domain_operator_node_provisioner.tf
@@ -42,8 +42,10 @@ resource "null_resource" "start_domain_operator_nodes" {
   count      = length(aws_instance.domain_operator_nodes)
   depends_on = [null_resource.setup_domain_operator_nodes]
 
-  # trigger node deployment on node object change
-  triggers = var.domain-operator-node-config.operator-nodes[count.index]
+  # trigger node re-deployment if the node config or its external IP changes
+  triggers = merge(var.domain-operator-node-config.operator-nodes[count.index], {
+    external-ip = aws_instance.domain_operator_nodes[count.index].public_ip
+  })
 
   connection {
     host           = aws_instance.domain_operator_nodes[count.index].public_ip

--- a/modules/network-primitives/domain_rpc_node_provisioner.tf
+++ b/modules/network-primitives/domain_rpc_node_provisioner.tf
@@ -62,6 +62,7 @@ resource "null_resource" "start_domain_rpc_nodes" {
     eth-cache            = var.domain-rpc-node-config.rpc-nodes[count.index].eth-cache
     enable-reverse-proxy = var.domain-rpc-node-config.enable-reverse-proxy
     enable-load-balancer = var.domain-rpc-node-config.enable-load-balancer
+    external-ip          = aws_instance.domain_rpc_nodes[count.index].public_ip
   }
 
   connection {

--- a/modules/network-primitives/farmer_node_provisioner.tf
+++ b/modules/network-primitives/farmer_node_provisioner.tf
@@ -54,8 +54,10 @@ resource "null_resource" "start_consensus_farmer_nodes" {
   count      = length(aws_instance.consensus_farmer_nodes)
   depends_on = [null_resource.setup_consensus_farmer_nodes]
 
-  # trigger node deployment if node details change
-  triggers = var.farmer-node-config.farmer-nodes[count.index]
+  # trigger node re-deployment if the node config or its external IP changes
+  triggers = merge(var.farmer-node-config.farmer-nodes[count.index], {
+    external-ip = aws_instance.consensus_farmer_nodes[count.index].public_ip
+  })
 
   connection {
     host           = aws_instance.consensus_farmer_nodes[count.index].public_ip

--- a/modules/network-primitives/rpc_node_provisioner.tf
+++ b/modules/network-primitives/rpc_node_provisioner.tf
@@ -59,6 +59,7 @@ resource "null_resource" "start_consensus_rpc_nodes" {
     sync-mode            = var.consensus-rpc-node-config.rpc-nodes[count.index].sync-mode
     enable-reverse-proxy = var.consensus-rpc-node-config.enable-reverse-proxy
     enable-load-balancer = var.consensus-rpc-node-config.enable-load-balancer
+    external-ip          = aws_instance.consensus_rpc_nodes[count.index].public_ip
   }
 
   connection {

--- a/resources/terraform/mainnet-chain-alerter/main.tf
+++ b/resources/terraform/mainnet-chain-alerter/main.tf
@@ -21,7 +21,7 @@ module "mainnet_chain_alerter" {
   instance = {
     network_name               = "mainnet"
     docker_tag                 = "v1.2.1"
-    instance_type              = "c3.xlarge"
+    instance_type              = "t3.large"
     rpc_url                    = "wss://rpc.mainnet.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url
     slack_secret               = var.slack_secret

--- a/resources/terraform/mainnet-chain-indexer/main.tf
+++ b/resources/terraform/mainnet-chain-indexer/main.tf
@@ -22,7 +22,7 @@ module "mainnet_chain_indexer" {
     network_name               = "mainnet"
     domain_fqdn                = "autonomys.xyz"
     docker_tag                 = "v1.2.1"
-    instance_type              = "c3.xlarge"
+    instance_type              = "c7a.large"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"
     consensus_rpc              = "wss://rpc.mainnet.autonomys.xyz/ws"

--- a/resources/terraform/mainnet-domains/main.tf
+++ b/resources/terraform/mainnet-domains/main.tf
@@ -32,7 +32,7 @@ module "mainnet_domains" {
   }
 
   domain-rpc-node-config = {
-    instance-type        = "c7a.4xlarge"
+    instance-type        = "c7a.2xlarge"
     disk-volume-size     = 500
     disk-volume-type     = var.disk_volume_type
     enable-reverse-proxy = true
@@ -51,7 +51,7 @@ module "mainnet_domains" {
   }
 
   domain-operator-node-config = {
-    instance-type    = "c7a.2xlarge"
+    instance-type    = "c7a.large"
     disk-volume-size = 300
     disk-volume-type = var.disk_volume_type
     operator-nodes = [

--- a/resources/terraform/mainnet-reward-distributor/main.tf
+++ b/resources/terraform/mainnet-reward-distributor/main.tf
@@ -22,7 +22,7 @@ module "mainnet_reward_distributor" {
   instance = {
     network_name        = "mainnet"
     docker_tag          = "latest"
-    instance_type       = "c3.large"
+    instance_type       = "t3.medium"
     rpc_url             = "wss://auto-evm.mainnet.autonomys.xyz/ws"
     interval_seconds    = 120
     tip_ai3             = 17.5


### PR DESCRIPTION
Two related changes here.

The node provisioners now include the instance's public IP in their `start_*` trigger. When an AWS-backed node's instance_type changes it gets a new auto-assigned IP on the stop/start, but the deploy only re-ran on node-config changes, so the node kept advertising its old, dead IP (I hit this right-sizing chronos, the auto-evm bootstrap looked down from outside while the box itself was fine). Now a resize re-runs the deploy and regenerates the config with the current IP. Bare-metal and timekeeper nodes use fixed IPs and are untouched.

The mainnet right-size: auto-evm rpc c7a.4xlarge to c7a.2xlarge, the two AWS operators c7a.2xlarge to c7a.large, and the three service boxes off the old c3 generation (chain-alerter to t3.large, chain-indexer to c7a.large, reward-distributor to t3.medium). consensus rpc-0 stays put, it's the public mainnet RPC and the only box with a real CPU peak, and nothing is cheaper at the 8 vCPU it needs. Everything resizes in place with EBS preserved (no resync), and the operators were done one at a time with bundle production confirmed in between.

They go together because with the trigger fix in place, each resize also refreshes the node's advertised IP in the same apply.
