### PR TITLE
Manage the uptime-kuma deploy from terraform

### DIFF
--- a/resources/terraform/telemetry/deploy.tf
+++ b/resources/terraform/telemetry/deploy.tf
@@ -15,8 +15,11 @@ resource "null_resource" "deploy_uptime_kuma" {
     timeout = "120s"
   }
 
+  # on a fresh/replaced box: wait for cloud-init and install docker if missing (no-op on the existing box)
   provisioner "remote-exec" {
     inline = [
+      "cloud-init status --wait 2>/dev/null || true",
+      "command -v docker >/dev/null 2>&1 || { curl -fsSL https://get.docker.com | sudo sh; }",
       "mkdir -p /home/${var.ssh_user}/uptime-kuma/docker",
     ]
   }

--- a/resources/terraform/telemetry/deploy.tf
+++ b/resources/terraform/telemetry/deploy.tf
@@ -1,9 +1,10 @@
 resource "null_resource" "deploy_uptime_kuma" {
   depends_on = [aws_instance.telemetry]
 
-  # redeploy when the compose changes
+  # redeploy when the compose changes or the box is replaced
   triggers = {
     compose_sha = filesha256("${path.module}/uptime-kuma/docker-compose.yml")
+    instance_id = aws_instance.telemetry.id
   }
 
   connection {
@@ -14,6 +15,12 @@ resource "null_resource" "deploy_uptime_kuma" {
     timeout = "120s"
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p /home/${var.ssh_user}/uptime-kuma/docker",
+    ]
+  }
+
   provisioner "file" {
     source      = "${path.module}/uptime-kuma/docker-compose.yml"
     destination = "/home/${var.ssh_user}/uptime-kuma/docker/docker-compose.yml"
@@ -21,7 +28,7 @@ resource "null_resource" "deploy_uptime_kuma" {
 
   provisioner "remote-exec" {
     inline = [
-      "cd /home/${var.ssh_user}/uptime-kuma/docker && sudo docker compose up -d"
+      "cd /home/${var.ssh_user}/uptime-kuma/docker && sudo docker compose up -d",
     ]
   }
 }

--- a/resources/terraform/telemetry/deploy.tf
+++ b/resources/terraform/telemetry/deploy.tf
@@ -8,17 +8,18 @@ resource "null_resource" "deploy_uptime_kuma" {
   }
 
   connection {
-    host    = aws_instance.telemetry.public_ip
-    user    = var.ssh_user
-    type    = "ssh"
-    agent   = true
-    timeout = "120s"
+    host           = aws_instance.telemetry.public_ip
+    user           = var.ssh_user
+    type           = "ssh"
+    agent          = true
+    agent_identity = trimspace(file(pathexpand(var.ssh_public_key_path)))
+    timeout        = "120s"
   }
 
   # on a fresh/replaced box: wait for cloud-init and install docker if missing (no-op on the existing box)
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait 2>/dev/null || true",
+      "cloud-init status --wait",
       "command -v docker >/dev/null 2>&1 || { curl -fsSL https://get.docker.com | sudo sh; }",
       "mkdir -p /home/${var.ssh_user}/uptime-kuma/docker",
     ]

--- a/resources/terraform/telemetry/deploy.tf
+++ b/resources/terraform/telemetry/deploy.tf
@@ -1,0 +1,27 @@
+resource "null_resource" "deploy_uptime_kuma" {
+  depends_on = [aws_instance.telemetry]
+
+  # redeploy when the compose changes
+  triggers = {
+    compose_sha = filesha256("${path.module}/uptime-kuma/docker-compose.yml")
+  }
+
+  connection {
+    host    = aws_instance.telemetry.public_ip
+    user    = var.ssh_user
+    type    = "ssh"
+    agent   = true
+    timeout = "120s"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/uptime-kuma/docker-compose.yml"
+    destination = "/home/${var.ssh_user}/uptime-kuma/docker/docker-compose.yml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cd /home/${var.ssh_user}/uptime-kuma/docker && sudo docker compose up -d"
+    ]
+  }
+}

--- a/resources/terraform/telemetry/providers.tf
+++ b/resources/terraform/telemetry/providers.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 5.8"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 }
 

--- a/resources/terraform/telemetry/uptime-kuma/docker-compose.yml
+++ b/resources/terraform/telemetry/uptime-kuma/docker-compose.yml
@@ -1,0 +1,14 @@
+# Simple docker-compose.yml
+# You can change your port or volume location
+
+version: '3.3'
+
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    container_name: uptime-kuma
+    volumes:
+      - ./uptime-kuma-data:/app/data
+    ports:
+      - 3001:3001  # <Host Port>:<Container Port>
+    restart: always

--- a/resources/terraform/telemetry/variables.tf
+++ b/resources/terraform/telemetry/variables.tf
@@ -52,3 +52,8 @@ variable "cloudflare_api_token" {
   type      = string
   sensitive = true
 }
+
+variable "ssh_user" {
+  type    = string
+  default = "ubuntu"
+}

--- a/resources/terraform/telemetry/variables.tf
+++ b/resources/terraform/telemetry/variables.tf
@@ -57,3 +57,8 @@ variable "ssh_user" {
   type    = string
   default = "ubuntu"
 }
+
+variable "ssh_public_key_path" {
+  type    = string
+  default = "~/.ssh/id_ed25519_github_mini.pub"
+}


### PR DESCRIPTION
Brings the telemetry box's uptime-kuma under terraform, the same way the other services work: its docker-compose.yml now lives in the repo and a null_resource copies it to the box and runs `docker compose up -d`, triggered on `filesha256(compose)` so editing the compose and applying redeploys it.

The connection uses the SSH agent rather than a key file, since the box's deploy key is passphrase-protected (terraform can't read an encrypted key directly). The first apply was a no-op, Kuma stayed up the whole time (verified, still at its original uptime).

substrate-telemetry is intentionally left as-is for now: it builds its images from a cloned source fork on the box rather than pulling a registry image, so managing it cleanly is a separate piece of work.