### PR TITLE
Remove stale auto-drive taurus DNS records

### DIFF
--- a/resources/terraform/dns/autonomys_xyz.tf
+++ b/resources/terraform/dns/autonomys_xyz.tf
@@ -75,17 +75,6 @@ resource "cloudflare_dns_record" "terraform_managed_resource_7e1937606b6f23fb1ac
   settings = {}
 }
 
-resource "cloudflare_dns_record" "terraform_managed_resource_9997d854598a4a8076694b3e8eaf2c4c_25" {
-  content  = local.proxied_data.autonomys_xyz.download_taurus_autodrive
-  name     = "download.taurus.staging.auto-drive.autonomys.xyz"
-  proxied  = true
-  tags     = []
-  ttl      = 1
-  type     = "A"
-  zone_id  = data.cloudflare_zone.autonomys_xyz.zone_id
-  settings = {}
-}
-
 resource "cloudflare_dns_record" "terraform_managed_resource_9df0a22995207a238a5d29542f673c24_26" {
   content  = local.proxied_data.autonomys_xyz.explorer_evm_taurus_0
   name     = "evm.taurus.autonomys.xyz"
@@ -264,17 +253,6 @@ resource "cloudflare_dns_record" "terraform_managed_resource_c537387f2cd9376569e
   settings = {}
 }
 
-resource "cloudflare_dns_record" "terraform_managed_resource_2d7a0d0117c649edf3f50cefc63d53cd_42" {
-  content  = local.proxied_data.autonomys_xyz.autodrive_taurus_public
-  name     = "public.taurus.auto-drive.autonomys.xyz"
-  proxied  = true
-  tags     = []
-  ttl      = 1
-  type     = "A"
-  zone_id  = data.cloudflare_zone.autonomys_xyz.zone_id
-  settings = {}
-}
-
 resource "cloudflare_dns_record" "terraform_managed_resource_565610ef1e10ab365a52ac67d77ea115_53" {
   content  = "15.204.77.126"
   name     = "scv.explorer.auto-evm.mainnet.autonomys.xyz"
@@ -341,27 +319,6 @@ resource "cloudflare_dns_record" "terraform_managed_resource_1ec194881fa074ac7a6
   settings = {}
 }
 
-resource "cloudflare_dns_record" "terraform_managed_resource_095a86249dfb3454e80fc07e1a2f408b_59" {
-  content  = local.proxied_data.autonomys_xyz.autodrive_taurus
-  name     = "taurus.auto-drive.autonomys.xyz"
-  proxied  = true
-  tags     = []
-  ttl      = 1
-  type     = "A"
-  zone_id  = data.cloudflare_zone.autonomys_xyz.zone_id
-  settings = {}
-}
-
-resource "cloudflare_dns_record" "terraform_managed_resource_bbe3e3b3258956cc8bd7ca525b5c3cd9_60" {
-  content  = local.proxied_data.autonomys_xyz.staging_taurus_autodrive
-  name     = "taurus.staging.auto-drive.autonomys.xyz"
-  proxied  = true
-  tags     = []
-  ttl      = 1
-  type     = "A"
-  zone_id  = data.cloudflare_zone.autonomys_xyz.zone_id
-  settings = {}
-}
 
 resource "cloudflare_dns_record" "terraform_managed_resource_15fab5021f8bb0efe09d3d377860fcb7_61" {
   content  = local.proxied_data.autonomys_xyz.uptime


### PR DESCRIPTION
## Summary

Removes 4 Cloudflare DNS records in `resources/terraform/dns/autonomys_xyz.tf` that point at long-destroyed auto-drive taurus AWS resources. Single-file change, 43 lines deleted. Closes #521.

## Records removed

| Name | proxied.json key |
|---|---|
| `download.taurus.staging.auto-drive.autonomys.xyz` | `download_taurus_autodrive` |
| `public.taurus.auto-drive.autonomys.xyz` | `autodrive_taurus_public` |
| `taurus.auto-drive.autonomys.xyz` | `autodrive_taurus` |
| `taurus.staging.auto-drive.autonomys.xyz` | `staging_taurus_autodrive` |

## AWS-side audit (confirmed clean before this PR)

The 12 backing resources from these records were destroyed during PR #520's apply. Re-verified at the time of this PR:

```
$ aws ec2 describe-addresses --region us-west-2 \
    --allocation-ids eipalloc-024ff74940f1cfad4 eipalloc-0c5ec4e48a70358c0
→ InvalidAllocationID.NotFound  (both EIPs gone)

$ aws iam list-roles            ... filter taurus-backend|multi-network-gateway|auto-drive-taurus  → 0 rows
$ aws iam list-instance-profiles ... same filter                                                     → 0 rows
$ aws iam list-policies --scope Local ... same filter                                                → 0 rows
$ aws ec2 describe-instances --region us-west-2 --filters Name=ip-address,Values=44.227.27.143,35.167.219.222 → 0 rows
```

Old EIPs were 44.227.27.143 (taurus backend) and 35.167.219.222 (multi-network gateway) — neither held by any AWS account resource now.

## ⚠️ Plan not run locally

The author did not have a Cloudflare API token available to run `manage.sh dns plan` locally. **The expected plan is exactly 4 destroys, no adds, no other changes.** The operator running the apply MUST stop and investigate if the plan shows anything else.

## Out-of-band follow-up after merge + apply

The 4 `proxied.json` keys in Infisical (`download_taurus_autodrive`, `autodrive_taurus_public`, `autodrive_taurus`, `staging_taurus_autodrive`) become unreferenced after this PR. Removing them is strictly optional (Terraform won't look them up anymore) but cleaner. Single Infisical edit.

## Test plan

- [x] Review the diff (4 record blocks gone from `dns/autonomys_xyz.tf`)
- [ ] `manage.sh dns plan` → confirm 4 destroys / 0 adds / 0 changes; **stop if any other diff**
- [ ] Apply
- [ ] (Optional) Prune the 4 orphan keys from Infisical's `proxied.json`
- [ ] Confirm `dig +short taurus.auto-drive.autonomys.xyz` returns NXDOMAIN / no answer
- [ ] Close #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)