### PR TITLE
Downsize auto-drive RDS from t4g.2xlarge to t4g.xlarge

### DIFF
--- a/resources/terraform/auto-drive-production/main.tf
+++ b/resources/terraform/auto-drive-production/main.tf
@@ -33,7 +33,7 @@ module "auto_drive" {
   }
 
   database = {
-    instance_class          = "db.t4g.2xlarge"
+    instance_class          = "db.t4g.xlarge"
     engine_version          = "17.9"
     allocated_storage       = 50
     max_storage             = 500


### PR DESCRIPTION
## Summary

Single-line change to halve the auto-drive PostgreSQL instance: `db.t4g.2xlarge` → `db.t4g.xlarge`. Going from 8 vCPU / 32 GB RAM to 4 vCPU / 16 GB RAM. CloudWatch audit confirms the workload is using a tiny fraction of 2xlarge's capacity; xlarge has ample headroom across every dimension.

Roughly halves the on-demand hourly cost of the DB tier (storage and IO charges unchanged).

## Sizing audit (30 days, mainnet workload)

| Metric | Reading on 2xlarge | xlarge implication |
|---|---|---|
| **CPU average** | 1–2% across all 30 days | Negligible. Massively over-provisioned at 2xlarge. |
| **CPU max — typical day** | < 5% | Trivial on xlarge |
| **CPU max — worst spike (2026-05-20, 1 minute)** | 52.93% (~4.2 vCPUs) | Scales to ~106% briefly. T-series burst credits absorb (~21 credits out of 2304 budget on xlarge). |
| **CPU max — sustained spike (2026-06-17, 14 minutes)** | 35–46% (~3 vCPUs) | Scales to ~70–93% on xlarge — high but below 100%, no queueing. |
| **CPU surplus credits charged (30 days)** | **Zero** | Never exceeded baseline + accumulated burst on 2xlarge. xlarge will not exceed either. |
| **CPU credit balance** | Pinned at instance max (4608) the entire 30 days, with two trivial noise dips to 4603 | Earning credits faster than burning. xlarge's max is 2304 — still ample. |
| **Freeable memory minimum** | ~22.7 GB free of 32 GB | Postgres is using ~9 GB. On xlarge (16 GB total) we'd still have ~7 GB free. |
| **Database connections max** | 37 (avg 5–7) | xlarge supports ~1800 max_connections — not a constraint. |

The worst spike investigation drilled into per-minute resolution for `2026-06-17` (yesterday, 16:12–16:26 UTC+1): the spike is a clean 14-minute window of elevated CPU (35–46% on 2xlarge), then drops below 20%. Not a sustained hours-long load. xlarge handles this comfortably via T-series burst credits.

## Plan output

```
~ resource "aws_db_instance" "this" {
    id                                    = "db-RJD77YTXBEDCZJTBJM4XGW63MU"
  ~ instance_class                        = "db.t4g.2xlarge" -> "db.t4g.xlarge"
    # (61 unchanged attributes hidden)
  }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Single in-place attribute update. DB instance id preserved. No resource recreation. Nothing else touched.

## Operational considerations

This is a **production database resize**. Multi-AZ is enabled (`multi_az = true`), so AWS handles the modification with a controlled failover:

1. AWS modifies the standby instance first (no app impact)
2. AWS performs a failover (~30–60 seconds of connection drops — clients with retry reconnect transparently; long-running queries may fail and need to retry)
3. AWS modifies the old primary (now standby; no app impact)
4. Wall-clock: ~5–15 minutes. User-visible disruption: ~1 minute during failover.

The module already has `apply_immediately = true`, so the change takes effect on apply, not at a maintenance window.

## Apply checklist

- [x] Review + approve
- [x] Merge
- [x] Take a manual snapshot immediately before apply (belt-and-braces rollback option):
  ```bash
  aws rds create-db-snapshot --region us-west-2 \
    --db-instance-identifier auto-drive \
    --db-snapshot-identifier auto-drive-pre-resize-$(date +%Y%m%d-%H%M)
  ```
- [x] Wait for snapshot to reach `available` (~5 min)
- [x] Apply during a low-traffic window: `manage.sh auto-drive-production apply`
- [x] Post-apply: watch `CPUUtilization` for the first hour, confirm no `CPUSurplusCreditsCharged` events appear, check application logs for AWS/DB errors
- [x] Confirm `aws rds describe-db-instances --region us-west-2 --db-instance-identifier auto-drive --query 'DBInstances[0].DBInstanceClass'` reports `db.t4g.xlarge`

## Rollback

If anything degrades post-resize: revert `instance_class` to `db.t4g.2xlarge`, apply, same failover sequence. Sub-15-minute recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)