### PR TITLE
Mainnet reward-distributor wind-down: tip 28.5, daily cap 22000

### DIFF
--- a/resources/terraform/mainnet-reward-distributor/main.tf
+++ b/resources/terraform/mainnet-reward-distributor/main.tf
@@ -25,8 +25,8 @@ module "mainnet_reward_distributor" {
     instance_type       = "t3.medium"
     rpc_url             = "wss://auto-evm.mainnet.autonomys.xyz/ws"
     interval_seconds    = 120
-    tip_ai3             = 17.5
-    daily_ai3_cap       = 16000
+    tip_ai3             = 28.5
+    daily_ai3_cap       = 22000
     max_retries         = 5
     mortality_blocks    = 64
     confirmation_blocks = 5


### PR DESCRIPTION
Wind-down go-live for the mainnet operator reward program. Raises the tip from 17.5 to 28.5 per period and the daily cap from 16000 to 22000, so the new rate (~20,520/day) runs unclipped by the cap. This drains the reward pool to roughly end of August, after which emissions stop on their own. The wallet is being topped up over the next couple of days.