### PR TITLE
Bump chronos + mainnet chain-indexer to v1.2.2

### DIFF
--- a/resources/terraform/chronos-chain-indexer/main.tf
+++ b/resources/terraform/chronos-chain-indexer/main.tf
@@ -21,7 +21,7 @@ module "chronos_chain_indexer" {
   instance = {
     network_name               = "chronos"
     domain_fqdn                = "autonomys.xyz"
-    docker_tag                 = "v1.2.1"
+    docker_tag                 = "v1.2.2"
     instance_type              = "c7a.large"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"

--- a/resources/terraform/mainnet-chain-indexer/main.tf
+++ b/resources/terraform/mainnet-chain-indexer/main.tf
@@ -21,7 +21,7 @@ module "mainnet_chain_indexer" {
   instance = {
     network_name               = "mainnet"
     domain_fqdn                = "autonomys.xyz"
-    docker_tag                 = "v1.2.1"
+    docker_tag                 = "v1.2.2"
     instance_type              = "c7a.large"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"


### PR DESCRIPTION
Rolls the chain-indexer to v1.2.2 on chronos and mainnet. v1.2.2 pins stable V14 metadata instead of subxt's unstable metadata and makes event extraction fail-loud, fixing the spec-10 decode crash that's been flapping the chronos indexer. Chronos recovers and re-indexes from its stuck checkpoint; mainnet is unaffected today but gets it pre-emptively so it rides through its own spec-10 upgrade without a mid-upgrade redeploy.