### PR TITLE
bump chain-alerter to v1.2.2 (chronos + mainnet)

### DIFF
--- a/resources/terraform/chronos-chain-alerter/main.tf
+++ b/resources/terraform/chronos-chain-alerter/main.tf
@@ -20,7 +20,7 @@ module "chronos_chain_alerter" {
 
   instance = {
     network_name               = "chronos"
-    docker_tag                 = "v1.2.1"
+    docker_tag                 = "v1.2.2"
     instance_type              = "t3.medium"
     rpc_url                    = "wss://rpc.chronos.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url

--- a/resources/terraform/mainnet-chain-alerter/main.tf
+++ b/resources/terraform/mainnet-chain-alerter/main.tf
@@ -20,7 +20,7 @@ module "mainnet_chain_alerter" {
 
   instance = {
     network_name               = "mainnet"
-    docker_tag                 = "v1.2.1"
+    docker_tag                 = "v1.2.2"
     instance_type              = "t3.large"
     rpc_url                    = "wss://rpc.mainnet.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url


### PR DESCRIPTION
The chain-indexers went to v1.2.2 for the subxt spec-10 metadata fix, but the chain-alerters were left on v1.2.1. They run the same chain-decode path, and the chronos alerter has been crash-looping on the same error since chronos hit spec-10. This bumps both alerters to v1.2.2: chronos to stop the crash-loop, mainnet pre-emptively before it hits the same wall at its next triggering upgrade.