### PR TITLE
Unproxy agent.autonomys.xyz CNAME for Webflow connection check

### DIFF
--- a/resources/terraform/dns/autonomys_xyz.tf
+++ b/resources/terraform/dns/autonomys_xyz.tf
@@ -1095,7 +1095,7 @@ resource "cloudflare_dns_record" "webflow_verification_agent" {
 resource "cloudflare_dns_record" "agent_autonomys_xyz" {
   content = "cdn.webflow.com"
   name    = "agent.autonomys.xyz"
-  proxied = true
+  proxied = false
   tags    = []
   ttl     = 1
   type    = "CNAME"


### PR DESCRIPTION
## Summary
- Set `proxied = false` on the `agent.autonomys.xyz` CNAME to `cdn.webflow.com`

## Purpose
Webflow's domain connection check failed after #575: with the Cloudflare proxy on, public DNS returns Cloudflare anycast IPs instead of a CNAME to `cdn.webflow.com`, so Webflow cannot see the record. DNS-only lets the CNAME resolve as-is; Webflow serves SSL directly.

## Rollout
```
./resources/terraform/manage.sh dns plan
./resources/terraform/manage.sh dns apply
```
Then retry the connection in Webflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)