### PR TITLE
bump chain-alerter + chain-indexer to v1.2.3

### DIFF
--- a/resources/terraform/chronos-chain-alerter/main.tf
+++ b/resources/terraform/chronos-chain-alerter/main.tf
@@ -20,7 +20,7 @@ module "chronos_chain_alerter" {
 
   instance = {
     network_name               = "chronos"
-    docker_tag                 = "v1.2.2"
+    docker_tag                 = "v1.2.3"
     instance_type              = "t3.medium"
     rpc_url                    = "wss://rpc.chronos.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url

--- a/resources/terraform/chronos-chain-indexer/main.tf
+++ b/resources/terraform/chronos-chain-indexer/main.tf
@@ -21,7 +21,7 @@ module "chronos_chain_indexer" {
   instance = {
     network_name               = "chronos"
     domain_fqdn                = "autonomys.xyz"
-    docker_tag                 = "v1.2.2"
+    docker_tag                 = "v1.2.3"
     instance_type              = "c7a.large"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"

--- a/resources/terraform/mainnet-chain-alerter/main.tf
+++ b/resources/terraform/mainnet-chain-alerter/main.tf
@@ -20,7 +20,7 @@ module "mainnet_chain_alerter" {
 
   instance = {
     network_name               = "mainnet"
-    docker_tag                 = "v1.2.2"
+    docker_tag                 = "v1.2.3"
     instance_type              = "t3.large"
     rpc_url                    = "wss://rpc.mainnet.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url

--- a/resources/terraform/mainnet-chain-indexer/main.tf
+++ b/resources/terraform/mainnet-chain-indexer/main.tf
@@ -21,7 +21,7 @@ module "mainnet_chain_indexer" {
   instance = {
     network_name               = "mainnet"
     domain_fqdn                = "autonomys.xyz"
-    docker_tag                 = "v1.2.2"
+    docker_tag                 = "v1.2.3"
     instance_type              = "c7a.large"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"


### PR DESCRIPTION
Rolls chain-alerter and chain-indexer to v1.2.3 on both networks.

1.2.3 fixes a silent event-loss bug: `shared` pinned subxt metadata at chain head and used it to decode every block, so a container that restarted after the mainnet spec-11 upgrade (block 8907820) with a checkpoint below that block would decode pre-upgrade blocks with spec-11 metadata and quietly drop staking and XDM events. Normal in-order tip processing wasn't affected.

I checked our containers: all three mainnet indexer restarts since the upgrade resumed at 8910408, 8910564 and 8918046, all above 8907820, so we never hit the bad window and no re-index is needed.

Straight image bump, no migration or config change.
