### PR TITLE
prune stale images and cap journald

### DIFF
--- a/modules/chain-alerts/instances.tf
+++ b/modules/chain-alerts/instances.tf
@@ -116,6 +116,9 @@ resource "null_resource" "start_chain_alert_node" {
 
       # start subspace node
       sudo docker compose -f /home/${var.deployer.ssh_user}/subspace/docker-compose.yml up -d
+
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
       EOT
     ]
   }

--- a/modules/chain-indexer/instances.tf
+++ b/modules/chain-indexer/instances.tf
@@ -126,6 +126,9 @@ resource "null_resource" "start_chain_indexer_node" {
 
       # start subspace node
       sudo docker compose -f /home/${var.deployer.ssh_user}/subspace/docker-compose.yml up -d
+
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
       EOT
     ]
   }

--- a/modules/network-primitives/bare_bootstrap_domain_node_provisioner.tf
+++ b/modules/network-primitives/bare_bootstrap_domain_node_provisioner.tf
@@ -86,6 +86,9 @@ resource "null_resource" "start-bare-domain-bootstrap-nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/network-primitives/bare_bootstrap_node_provisioner.tf
+++ b/modules/network-primitives/bare_bootstrap_node_provisioner.tf
@@ -85,6 +85,9 @@ resource "null_resource" "start-bare-consensus-boostrap-nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/network-primitives/bare_domain_operator_node_provisioner.tf
+++ b/modules/network-primitives/bare_domain_operator_node_provisioner.tf
@@ -85,6 +85,9 @@ resource "null_resource" "start_bare_domain_operator_nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # wait until container is created
       sudo sh -c 'until docker ps -f "name=node" --format "{{.ID}}" | grep -q .; do sleep 1; done'
 

--- a/modules/network-primitives/bare_rpc_node_provisioner.tf
+++ b/modules/network-primitives/bare_rpc_node_provisioner.tf
@@ -102,6 +102,9 @@ resource "null_resource" "start_bare_consensus_rpc_nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/network-primitives/bootstrap_domain_node_provisioner.tf
+++ b/modules/network-primitives/bootstrap_domain_node_provisioner.tf
@@ -91,6 +91,9 @@ resource "null_resource" "start-domain-bootstrap-nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/network-primitives/bootstrap_node_provisioner.tf
+++ b/modules/network-primitives/bootstrap_node_provisioner.tf
@@ -90,6 +90,9 @@ resource "null_resource" "start-consensus-boostrap-nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/network-primitives/domain_operator_node_provisioner.tf
+++ b/modules/network-primitives/domain_operator_node_provisioner.tf
@@ -90,6 +90,9 @@ resource "null_resource" "start_domain_operator_nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # wait until container is created
       sudo sh -c 'until docker ps -f "name=node" --format "{{.ID}}" | grep -q .; do sleep 1; done'
 

--- a/modules/network-primitives/domain_rpc_node_provisioner.tf
+++ b/modules/network-primitives/domain_rpc_node_provisioner.tf
@@ -111,6 +111,9 @@ resource "null_resource" "start_domain_rpc_nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/network-primitives/farmer_node_provisioner.tf
+++ b/modules/network-primitives/farmer_node_provisioner.tf
@@ -105,6 +105,9 @@ resource "null_resource" "start_consensus_farmer_nodes" {
       # start subspace
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/network-primitives/rpc_node_provisioner.tf
+++ b/modules/network-primitives/rpc_node_provisioner.tf
@@ -106,6 +106,9 @@ resource "null_resource" "start_consensus_rpc_nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/network-primitives/timekeeper_node_provisioner.tf
+++ b/modules/network-primitives/timekeeper_node_provisioner.tf
@@ -142,6 +142,9 @@ resource "null_resource" "start_timekeeper_nodes" {
       # start subspace node
       sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d
 
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
+
       # delete config file
       sudo rm -rf /home/${var.ssh_user}/subspace/config.toml
       EOT

--- a/modules/operator-reward-distributor/instances.tf
+++ b/modules/operator-reward-distributor/instances.tf
@@ -126,6 +126,9 @@ resource "null_resource" "start_reward_distributor_node" {
 
       # start docker service
       sudo docker compose -f /home/${var.deployer.ssh_user}/subspace/docker-compose.yml up -d
+
+      # drop images left by previous deploys; the running one is protected
+      sudo docker image prune -af
       EOT
     ]
   }

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -17,6 +17,14 @@ echo \
 sudo apt update -y
 sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
+# journald defaults to 10% of the filesystem; on an 8G root that grows to ~800M
+sudo mkdir -p /etc/systemd/journald.conf.d
+sudo tee /etc/systemd/journald.conf.d/size.conf > /dev/null <<'EOF'
+[Journal]
+SystemMaxUse=200M
+EOF
+sudo systemctl restart systemd-journald
+
 # set max socket connections
 if ! (grep -iq "net.core.somaxconn" /etc/sysctl.conf && sed -i 's/.*net.core.somaxconn.*/net.core.somaxconn=65535/' /etc/sysctl.conf); then
   sudo echo "net.core.somaxconn=65535" >> /etc/sysctl.conf


### PR DESCRIPTION
Both chain-alerter boxes filled up their 8G root disks: chronos hit 93% and mainnet 88%. I cleared them by hand, but nothing stops it recurring, so this fixes the two causes.

Every tag bump pulls a new image and leaves the old one behind, and nothing ever prunes. That was ~2.3GB of dead images on each alerter, 88% of the docker footprint. So a prune goes in after `up -d` at every deploy site. The running container's image is protected, so this only ever removes what previous deploys stranded. It's the same pattern on the node hosts, they just have 485G disks so nobody noticed.

The other half was journald: no size limit set, so it defaults to 10% of the filesystem and grows unbounded (777M on chronos). Capping it at 200M in installer.sh covers every host we build from here on.

Worth knowing how these two land differently. The prune rides `start_*`, which triggers on config changes, so it applies on each host's next deploy. installer.sh runs from `setup_*`, which has no triggers and only ever runs at instance creation, so the journald cap won't reach hosts that already exist. I'm setting that by hand on the current fleet.
