### PR TITLE
replace new relic with node-exporter, fix vmagent remote-write [blocked on vmetrics rebuild]

### DIFF
--- a/modules/network-primitives/bare_bootstrap_domain_node_provisioner.tf
+++ b/modules/network-primitives/bare_bootstrap_domain_node_provisioner.tf
@@ -73,7 +73,8 @@ resource "null_resource" "start-bare-domain-bootstrap-nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest domain-bootstrap \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.bare-domain-bootstrap-node-config.bootstrap-nodes[count.index].index} \
           --docker-tag ${var.bare-domain-bootstrap-node-config.bootstrap-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/bare_bootstrap_node_provisioner.tf
+++ b/modules/network-primitives/bare_bootstrap_node_provisioner.tf
@@ -73,7 +73,8 @@ resource "null_resource" "start-bare-consensus-boostrap-nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest bootstrap \
             --network ${var.network_name} \
-            --new-relic-api-key ${var.new_relic_api_key} \
+            --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
             --fqdn ${var.cloudflare_domain_fqdn} \
             --genesis-hash ${var.bare-consensus-bootstrap-node-config.genesis-hash} \
             --node-id ${var.bare-consensus-bootstrap-node-config.bootstrap-nodes[count.index].index} \

--- a/modules/network-primitives/bare_domain_operator_node_provisioner.tf
+++ b/modules/network-primitives/bare_domain_operator_node_provisioner.tf
@@ -71,7 +71,8 @@ resource "null_resource" "start_bare_domain_operator_nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest domain-operator \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.bare-domain-operator-node-config.operator-nodes[count.index].index} \
           --docker-tag ${var.bare-domain-operator-node-config.operator-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/bare_rpc_node_provisioner.tf
+++ b/modules/network-primitives/bare_rpc_node_provisioner.tf
@@ -87,7 +87,8 @@ resource "null_resource" "start_bare_consensus_rpc_nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest rpc \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.bare-consensus-rpc-node-config.rpc-nodes[count.index].index} \
           --docker-tag ${var.bare-consensus-rpc-node-config.rpc-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/bootstrap_domain_node_provisioner.tf
+++ b/modules/network-primitives/bootstrap_domain_node_provisioner.tf
@@ -77,7 +77,8 @@ resource "null_resource" "start-domain-bootstrap-nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest domain-bootstrap \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.domain-bootstrap-node-config.bootstrap-nodes[count.index].index} \
           --docker-tag ${var.domain-bootstrap-node-config.bootstrap-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/bootstrap_node_provisioner.tf
+++ b/modules/network-primitives/bootstrap_node_provisioner.tf
@@ -77,7 +77,8 @@ resource "null_resource" "start-consensus-boostrap-nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest bootstrap \
             --network ${var.network_name} \
-            --new-relic-api-key ${var.new_relic_api_key} \
+            --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
             --fqdn ${var.cloudflare_domain_fqdn} \
             --genesis-hash ${var.consensus-bootstrap-node-config.genesis-hash} \
             --node-id ${var.consensus-bootstrap-node-config.bootstrap-nodes[count.index].index} \

--- a/modules/network-primitives/domain_operator_node_provisioner.tf
+++ b/modules/network-primitives/domain_operator_node_provisioner.tf
@@ -75,7 +75,8 @@ resource "null_resource" "start_domain_operator_nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest domain-operator \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.domain-operator-node-config.operator-nodes[count.index].index} \
           --docker-tag ${var.domain-operator-node-config.operator-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/domain_rpc_node_provisioner.tf
+++ b/modules/network-primitives/domain_rpc_node_provisioner.tf
@@ -93,7 +93,8 @@ resource "null_resource" "start_domain_rpc_nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest domain-rpc \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.domain-rpc-node-config.rpc-nodes[count.index].index} \
           --docker-tag ${var.domain-rpc-node-config.rpc-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/farmer_node_provisioner.tf
+++ b/modules/network-primitives/farmer_node_provisioner.tf
@@ -87,7 +87,8 @@ resource "null_resource" "start_consensus_farmer_nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest farmer \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.farmer-node-config.farmer-nodes[count.index].index} \
           --docker-tag ${var.farmer-node-config.farmer-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/rpc_node_provisioner.tf
+++ b/modules/network-primitives/rpc_node_provisioner.tf
@@ -90,7 +90,8 @@ resource "null_resource" "start_consensus_rpc_nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest rpc \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.consensus-rpc-node-config.rpc-nodes[count.index].index} \
           --docker-tag ${var.consensus-rpc-node-config.rpc-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/timekeeper_node_provisioner.tf
+++ b/modules/network-primitives/timekeeper_node_provisioner.tf
@@ -130,7 +130,8 @@ resource "null_resource" "start_timekeeper_nodes" {
       # create docker compose
       sudo docker run --rm --pull always -v /home/${var.ssh_user}/subspace:/data ghcr.io/autonomys/infra/node-utils:latest timekeeper \
           --network ${var.network_name} \
-          --new-relic-api-key ${var.new_relic_api_key} \
+          --vmetrics-username ${var.vmetrics_username} \
+          --vmetrics-password ${var.vmetrics_password} \
           --fqdn ${var.cloudflare_domain_fqdn} \
           --node-id ${var.timekeeper-node-config.timekeeper-nodes[count.index].index} \
           --docker-tag ${var.timekeeper-node-config.timekeeper-nodes[count.index].docker-tag} \

--- a/modules/network-primitives/variables.tf
+++ b/modules/network-primitives/variables.tf
@@ -12,8 +12,14 @@ variable "aws_access_key" {
   default     = null
 }
 
-variable "new_relic_api_key" {
-  description = "New relic API Key"
+variable "vmetrics_username" {
+  description = "Basic-auth username for the VictoriaMetrics remote-write endpoint"
+  type        = string
+  sensitive   = true
+}
+
+variable "vmetrics_password" {
+  description = "Basic-auth password for the VictoriaMetrics remote-write endpoint"
   type        = string
   sensitive   = true
 }

--- a/modules/node-utils/src/cli.rs
+++ b/modules/node-utils/src/cli.rs
@@ -41,9 +41,12 @@ pub struct CommonParams {
     /// Ex: mainnet, devnet etc..
     #[arg(long, required = true)]
     pub network: String,
-    /// New relic API Key
+    /// Basic-auth username for the VictoriaMetrics remote-write endpoint
     #[arg(long, required = true)]
-    pub new_relic_api_key: String,
+    pub vmetrics_username: String,
+    /// Basic-auth password for the VictoriaMetrics remote-write endpoint
+    #[arg(long, required = true)]
+    pub vmetrics_password: String,
     /// Domain name.ex: subspace.network
     #[arg(long, required = true)]
     pub fqdn: String,

--- a/modules/node-utils/src/compose_create.rs
+++ b/modules/node-utils/src/compose_create.rs
@@ -37,6 +37,7 @@ pub(crate) fn create_boostrap_node_docker_compose(
                 port: "9616".to_string(),
             },
         ],
+        host_job_name: format!("{network_name}-bootstrap-{node_id}-host"),
     })?;
     Ok(())
 }
@@ -53,6 +54,7 @@ pub(crate) fn create_rpc_node_docker_compose(rpc_params: RpcParams) -> Result<()
             node: "node".to_string(),
             port: "9615".to_string(),
         }],
+        host_job_name: format!("{network_name}-rpc-{node_id}-host"),
     })?;
 
     Ok(())
@@ -70,6 +72,7 @@ pub(crate) fn create_timekeeper_node_docker_compose(params: TimekeeperParams) ->
             node: "node".to_string(),
             port: "9615".to_string(),
         }],
+        host_job_name: format!("{network_name}-timekeeper-{node_id}-host"),
     })?;
     Ok(())
 }
@@ -97,6 +100,7 @@ pub(crate) fn create_farmer_node_docker_compose(farmer_params: FarmerParams) -> 
                 port: "9616".to_string(),
             },
         ],
+        host_job_name: format!("{network_name}-farmer-{node_id}-host"),
     })?;
 
     Ok(())
@@ -117,6 +121,7 @@ pub(crate) fn create_domain_bootstrap_node_docker_compose(
             node: "node".to_string(),
             port: "9615".to_string(),
         }],
+        host_job_name: format!("{network_name}-domain-{domain_id}-bootstrap-{node_id}-host"),
     })?;
     Ok(())
 }
@@ -136,6 +141,7 @@ pub(crate) fn create_domain_rpc_node_docker_compose(
             node: "node".to_string(),
             port: "9615".to_string(),
         }],
+        host_job_name: format!("{network_name}-domain-{domain_id}-rpc-{node_id}-host"),
     })?;
     Ok(())
 }
@@ -165,6 +171,7 @@ pub(crate) fn create_domain_operator_node_docker_compose(
             node: "node".to_string(),
             port: "9615".to_string(),
         }],
+        host_job_name: format!("{network_name}-domain-{domain_id}-operator-{operator_id}-host"),
     })?;
     Ok(())
 }

--- a/modules/node-utils/src/templates/docker-compose.hbs
+++ b/modules/node-utils/src/templates/docker-compose.hbs
@@ -25,22 +25,21 @@ services:
         command:
             - "--httpListenAddr=0.0.0.0:8429"
             - "--promscrape.config=/etc/prometheus/prometheus.yml"
-            - "--remoteWrite.url=http://vmetrics.subspace.network:8428/api/v1/write"
+            - "--remoteWrite.url=https://vmetrics.subspace.network/api/v1/write"
+            - "--remoteWrite.basicAuth.username={{vmetrics_username}}"
+            - "--remoteWrite.basicAuth.password={{vmetrics_password}}"
+        restart: unless-stopped
 
-    newrelic:
-        container_name: newrelic
-        image: newrelic/infrastructure:latest
-        cap_add:
-            - SYS_PTRACE
-        network_mode: bridge
+    node-exporter:
+        container_name: node-exporter
+        image: prom/node-exporter:v1.8.2
         pid: host
-        privileged: true
+        networks:
+            - node
         volumes:
-            - "/:/host:ro"
-            - "/var/run/docker.sock:/var/run/docker.sock"
-        environment:
-            NRIA_LICENSE_KEY: "{{new_relic_api_key}}"
-            NRIA_DISPLAY_NAME: "{{network_name}}-{{node_prefix}}-node-{{node_id}}"
+            - "/:/host:ro,rslave"
+        command:
+            - "--path.rootfs=/host"
         restart: unless-stopped
 
 {{#if rpc_node}}

--- a/modules/node-utils/src/templates/prometheus.hbs
+++ b/modules/node-utils/src/templates/prometheus.hbs
@@ -6,3 +6,7 @@ scrape_configs:
         - targets: ['{{this.node}}:{{this.port}}']
 
 {{/each}}
+    - job_name: '{{host_job_name}}'
+      scrape_interval: 15s
+      static_configs:
+        - targets: ['node-exporter:9100']

--- a/modules/node-utils/src/types.rs
+++ b/modules/node-utils/src/types.rs
@@ -89,6 +89,7 @@ pub struct PrometheusNodeData {
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct PrometheusTemplateData {
     pub nodes: Vec<PrometheusNodeData>,
+    pub host_job_name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -96,7 +97,8 @@ pub struct ComposeTemplateData {
     pub network_name: String,
     pub node_prefix: String,
     pub node_id: String,
-    pub new_relic_api_key: String,
+    pub vmetrics_username: String,
+    pub vmetrics_password: String,
     pub docker_tag: String,
     pub external_ip_v4: String,
     pub external_ip_v6: Option<String>,
@@ -123,7 +125,8 @@ impl ComposeTemplateData {
     ) -> ComposeTemplateData {
         let CommonParams {
             network,
-            new_relic_api_key,
+            vmetrics_username,
+            vmetrics_password,
             fqdn,
             node_id,
             docker_tag,
@@ -136,7 +139,8 @@ impl ComposeTemplateData {
             network_name: network.clone(),
             node_prefix: node_type,
             node_id: node_id.clone(),
-            new_relic_api_key,
+            vmetrics_username,
+            vmetrics_password,
             docker_tag,
             external_ip_v4,
             external_ip_v6,

--- a/resources/terraform/chronos/common.auto.tfvars.example
+++ b/resources/terraform/chronos/common.auto.tfvars.example
@@ -1,5 +1,6 @@
 cloudflare_account_id = ""
-new_relic_api_key     = ""
+vmetrics_username     = ""
+vmetrics_password     = ""
 timekeeper_node_ipv4 = {
   timekeeper-0 : ""
 }

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -11,7 +11,8 @@ module "chronos" {
   cloudflare_api_token   = var.cloudflare_api_token
   cloudflare_account_id  = var.cloudflare_account_id
   cloudflare_domain_fqdn = "autonomys.xyz"
-  new_relic_api_key      = var.new_relic_api_key
+  vmetrics_username      = var.vmetrics_username
+  vmetrics_password      = var.vmetrics_password
   aws_access_key         = var.aws_access_key
   aws_secret_key         = var.aws_secret_key
   aws_ssh_key_name       = var.aws_ssh_key_name

--- a/resources/terraform/chronos/variables.tf
+++ b/resources/terraform/chronos/variables.tf
@@ -44,8 +44,14 @@ variable "ssh_agent_identity" {
   type        = string
 }
 
-variable "new_relic_api_key" {
-  description = "New relic API Key"
+variable "vmetrics_username" {
+  description = "Basic-auth username for the VictoriaMetrics remote-write endpoint"
+  type        = string
+  sensitive   = true
+}
+
+variable "vmetrics_password" {
+  description = "Basic-auth password for the VictoriaMetrics remote-write endpoint"
   type        = string
   sensitive   = true
 }

--- a/resources/terraform/devnet/common.auto.tfvars.example
+++ b/resources/terraform/devnet/common.auto.tfvars.example
@@ -1,2 +1,3 @@
 cloudflare_account_id = ""
-new_relic_api_key     = ""
+vmetrics_username     = ""
+vmetrics_password     = ""

--- a/resources/terraform/devnet/main.tf
+++ b/resources/terraform/devnet/main.tf
@@ -11,7 +11,8 @@ module "devnet" {
   cloudflare_api_token   = var.cloudflare_api_token
   cloudflare_account_id  = var.cloudflare_account_id
   cloudflare_domain_fqdn = "autonomys.xyz"
-  new_relic_api_key      = var.new_relic_api_key
+  vmetrics_username      = var.vmetrics_username
+  vmetrics_password      = var.vmetrics_password
   aws_access_key         = var.aws_access_key
   aws_secret_key         = var.aws_secret_key
   aws_ssh_key_name       = var.aws_ssh_key_name

--- a/resources/terraform/devnet/variables.tf
+++ b/resources/terraform/devnet/variables.tf
@@ -44,8 +44,14 @@ variable "ssh_agent_identity" {
   type        = string
 }
 
-variable "new_relic_api_key" {
-  description = "New relic API Key"
+variable "vmetrics_username" {
+  description = "Basic-auth username for the VictoriaMetrics remote-write endpoint"
+  type        = string
+  sensitive   = true
+}
+
+variable "vmetrics_password" {
+  description = "Basic-auth password for the VictoriaMetrics remote-write endpoint"
   type        = string
   sensitive   = true
 }

--- a/resources/terraform/mainnet-consensus/common.auto.tfvars.example
+++ b/resources/terraform/mainnet-consensus/common.auto.tfvars.example
@@ -1,5 +1,6 @@
 cloudflare_account_id = ""
-new_relic_api_key     = ""
+vmetrics_username     = ""
+vmetrics_password     = ""
 timekeeper_node_ipv4 = {
   timekeeper-0 : ""
 }

--- a/resources/terraform/mainnet-consensus/main.tf
+++ b/resources/terraform/mainnet-consensus/main.tf
@@ -11,7 +11,8 @@ module "mainnet_consensus" {
   cloudflare_api_token   = var.cloudflare_api_token
   cloudflare_account_id  = var.cloudflare_account_id
   cloudflare_domain_fqdn = "autonomys.xyz"
-  new_relic_api_key      = var.new_relic_api_key
+  vmetrics_username      = var.vmetrics_username
+  vmetrics_password      = var.vmetrics_password
   aws_access_key         = var.aws_access_key
   aws_secret_key         = var.aws_secret_key
   aws_ssh_key_name       = var.aws_ssh_key_name

--- a/resources/terraform/mainnet-consensus/variables.tf
+++ b/resources/terraform/mainnet-consensus/variables.tf
@@ -15,8 +15,14 @@ variable "ssh_agent_identity" {
   type        = string
 }
 
-variable "new_relic_api_key" {
-  description = "New relic API Key"
+variable "vmetrics_username" {
+  description = "Basic-auth username for the VictoriaMetrics remote-write endpoint"
+  type        = string
+  sensitive   = true
+}
+
+variable "vmetrics_password" {
+  description = "Basic-auth password for the VictoriaMetrics remote-write endpoint"
   type        = string
   sensitive   = true
 }

--- a/resources/terraform/mainnet-domains/common.auto.tfvars.example
+++ b/resources/terraform/mainnet-domains/common.auto.tfvars.example
@@ -1,5 +1,6 @@
 cloudflare_account_id = ""
-new_relic_api_key     = ""
+vmetrics_username     = ""
+vmetrics_password     = ""
 bare_domain_operator_ipv4 = {
   operator_2 = ""
   operator_3 = ""

--- a/resources/terraform/mainnet-domains/main.tf
+++ b/resources/terraform/mainnet-domains/main.tf
@@ -11,7 +11,8 @@ module "mainnet_domains" {
   cloudflare_api_token   = var.cloudflare_api_token
   cloudflare_account_id  = var.cloudflare_account_id
   cloudflare_domain_fqdn = "autonomys.xyz"
-  new_relic_api_key      = var.new_relic_api_key
+  vmetrics_username      = var.vmetrics_username
+  vmetrics_password      = var.vmetrics_password
   aws_access_key         = var.aws_access_key
   aws_secret_key         = var.aws_secret_key
   aws_ssh_key_name       = var.aws_ssh_key_name

--- a/resources/terraform/mainnet-domains/variables.tf
+++ b/resources/terraform/mainnet-domains/variables.tf
@@ -38,8 +38,14 @@ variable "ssh_agent_identity" {
   type        = string
 }
 
-variable "new_relic_api_key" {
-  description = "New relic API Key"
+variable "vmetrics_username" {
+  description = "Basic-auth username for the VictoriaMetrics remote-write endpoint"
+  type        = string
+  sensitive   = true
+}
+
+variable "vmetrics_password" {
+  description = "Basic-auth password for the VictoriaMetrics remote-write endpoint"
   type        = string
   sensitive   = true
 }

--- a/resources/terraform/mainnet-foundation/common.auto.tfvars.example
+++ b/resources/terraform/mainnet-foundation/common.auto.tfvars.example
@@ -1,5 +1,6 @@
 cloudflare_account_id = ""
-new_relic_api_key     = ""
+vmetrics_username     = ""
+vmetrics_password     = ""
 consensus_rpc_ipv4 = {
   rpc-0 : ""
 }

--- a/resources/terraform/mainnet-foundation/main.tf
+++ b/resources/terraform/mainnet-foundation/main.tf
@@ -6,7 +6,8 @@ module "mainnet_foundation" {
   cloudflare_api_token   = var.cloudflare_api_token
   cloudflare_account_id  = var.cloudflare_account_id
   cloudflare_domain_fqdn = "subspace.foundation"
-  new_relic_api_key      = var.new_relic_api_key
+  vmetrics_username      = var.vmetrics_username
+  vmetrics_password      = var.vmetrics_password
   ssh_agent_identity     = var.ssh_agent_identity
   deployment_name        = "foundation"
 

--- a/resources/terraform/mainnet-foundation/variables.tf
+++ b/resources/terraform/mainnet-foundation/variables.tf
@@ -15,8 +15,14 @@ variable "ssh_agent_identity" {
   type        = string
 }
 
-variable "new_relic_api_key" {
-  description = "New relic API Key"
+variable "vmetrics_username" {
+  description = "Basic-auth username for the VictoriaMetrics remote-write endpoint"
+  type        = string
+  sensitive   = true
+}
+
+variable "vmetrics_password" {
+  description = "Basic-auth password for the VictoriaMetrics remote-write endpoint"
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
PARKED until the vmetrics box rebuild lands. Not ready to merge.

Replaces New Relic with node-exporter and fixes the vmagent remote-write, which has been failing fleet-wide because it pushes to port 8428 and Cloudflare never forwards that.

The reason this waits: we're rebuilding the metrics box from scratch (it's unreachable, nobody holds a key) and putting vmauth in front as a single authenticated gateway for both metrics and logs. That very likely changes the endpoint and the auth model this PR hardcodes, and nodes will want vector alongside vmagent to ship logs. Merging now would mean rolling every node twice.

Once the new box is up, I'll update the vmagent URL and auth here, add vector, and then roll it out in one pass.

New Relic removal and node-exporter stand on their own and shouldn't need rework.
