### PR TITLE
bump chronos nodes to chronos-2026-aug-18

### DIFF
--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -21,7 +21,7 @@ module "chronos" {
     genesis-hash = "91912b429ce7bf2975440a0920b46a892fddeeaed6ccc11c93f2d57ad1bd69ab"
     bootstrap-nodes = [
       {
-        docker-tag    = "chronos-2026-jun-14"
+        docker-tag    = "chronos-2026-aug-18"
         reserved-only = false
         index         = 0
         sync-mode     = "full"
@@ -39,7 +39,7 @@ module "chronos" {
     enable-load-balancer = true
     rpc-nodes = [
       {
-        docker-tag    = "chronos-2026-jun-14"
+        docker-tag    = "chronos-2026-aug-18"
         reserved-only = false
         index         = 0
         sync-mode     = "full"
@@ -50,14 +50,14 @@ module "chronos" {
   timekeeper-node-config = {
     timekeeper-nodes = [
       {
-        docker-tag    = "chronos-2026-jun-14"
+        docker-tag    = "chronos-2026-aug-18"
         reserved-only = false
         index         = 0
         sync-mode     = "full"
         ipv4          = var.timekeeper_node_ipv4.timekeeper-0
       },
       {
-        docker-tag    = "chronos-2026-jun-14"
+        docker-tag    = "chronos-2026-aug-18"
         reserved-only = false
         index         = 1
         sync-mode     = "full"
@@ -74,7 +74,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "chronos-2026-jun-14"
+        docker-tag    = "chronos-2026-aug-18"
         reserved-only = false
         index         = 0
         sync-mode     = "full"
@@ -92,7 +92,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "chronos-2026-jun-14"
+        docker-tag    = "chronos-2026-aug-18"
         reserved-only = false
         index         = 0
         sync-mode     = "full"
@@ -109,7 +109,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "chronos-2026-jun-14"
+        docker-tag    = "chronos-2026-aug-18"
         reserved-only = false
         index         = 0
         operator-id   = 0
@@ -118,7 +118,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "chronos-2026-jun-14"
+        docker-tag    = "chronos-2026-aug-18"
         reserved-only = false
         index         = 1
         operator-id   = 1


### PR DESCRIPTION
Rolls the 8 chronos nodes to chronos-2026-aug-18 (client 0.1.12, was 0.1.11 / jun-14).

Client only, no runtime change - both networks are already on spec 11. The security fixes are the reason to take it: wasmtime 36.0.13 and h2 0.4.16, the latter being unbounded empty DATA frames in the RPC server's HTTP/2 path, and our RPC nodes are public.

The GPU-plotting rework and the removal of the rocm builds don't touch us: chronos runs no farmers, and we only pull node and bootstrap-node off a single docker_tag. I grepped the repo for rocm and cuda and there's nothing.

Already applied and verified, node by node with -target: consensus bootstrap, consensus rpc, domain bootstrap, domain rpc, operator-0, operator-1, then the timekeepers one at a time. Chronos has no external PoT redundancy, so I kept one timekeeper on the old build as the survivor and confirmed blocks were still being produced before touching the second. All 8 report healthy on aug-18, both operators are claiming slots with zero bundle errors, and the chain is at 0.1.12-f8842d019cd with 12 peers.
